### PR TITLE
[BUG] Fix bug when adding multiple annotations

### DIFF
--- a/src/yarrow/yarrow_cls.py
+++ b/src/yarrow/yarrow_cls.py
@@ -12,7 +12,7 @@ Each class has a pydantic conversion:
 from copy import copy
 from datetime import datetime
 from warnings import warn
-
+import os
 from .yarrow import *
 
 
@@ -211,6 +211,9 @@ class Annotation:
 
     def __eq__(self, other) -> bool:
         if isinstance(other, Annotation):
+            if np.asarray(self.polygon).shape != np.asarray(other.polygon).shape:
+                return False
+            
             return all(
                 (
                     self.name == other.name,
@@ -670,6 +673,17 @@ class YarrowDataset:
         """
         for yarrow in yarrows:
             self.append(yarrow)
+
+    def save(self,yar_path:str,indent=None):
+        """Save the current YarrowDataset to a file
+
+        Args:
+            yar_path (str): Path to save the file
+            exist_ok (boolean, optional): If True, will overwrite the file if it already exists. Defaults to False.
+        """
+        os.makedirs(os.path.dirname(yar_path),exist_ok=True)
+        with open(yar_path, "w") as jsf:
+            json.dump(self.pydantic().model_dump(),jsf,indent=indent,default=str)
 
     @classmethod
     def from_yarrow(cls, yarrow: YarrowDataset_pydantic) -> "YarrowDataset":

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -1,0 +1,48 @@
+import os
+from copy import deepcopy
+from datetime import datetime
+import pytest
+from pydantic import ValidationError
+
+from yarrow import *
+
+@pytest.fixture
+def contributor_base():
+    return Contributor(
+        name="Jean Claude Vandamme",
+        human=True,
+        email="jcv@vive-la-belgique.com")
+
+@pytest.fixture
+def yarrow_base(contributor_base):
+    yarrow = YarrowDataset(
+        info=Info(date_created=datetime.now(),source='Bruxelles'),
+        images=[
+            Image(file_name='image1.jpg',height=100,width=100,date_captured=datetime.now()),
+            Image(file_name='image2.jpg',height=100,width=100,date_captured=datetime.now())],
+        contributors=[contributor_base]
+    )
+    return yarrow
+
+def test_create_multiple_annotations(yarrow_base:YarrowDataset,contributor_base:Contributor):
+    """In this test we make sure adding annotations with different polygon shape is working.
+
+    Args:
+        yarrow (YarrowDataset): _description_
+        contributor (Contributor): _description_
+    """
+    ann1 = Annotation(
+        contributor_base,
+        name='chaussure',
+        images=yarrow_base.images,
+        polygon=np.zeros((23,2))
+    )
+    ann2 = Annotation(
+        contributor_base,
+        name='chaussure',
+        images=yarrow_base.images,
+        polygon=np.zeros((10,2))
+    )
+    list_annotations = [ann1,ann2]
+    yarrow_base.add_annotations(list_annotations)
+

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -45,4 +45,7 @@ def test_create_multiple_annotations(yarrow_base:YarrowDataset,contributor_base:
     )
     list_annotations = [ann1,ann2]
     yarrow_base.add_annotations(list_annotations)
+    # We check that annotations were added correctly
+    assert np.asarray(yarrow_base.annotations[0].polygon).shape[0]==23,"First Polygon Shape == 23"
+    assert np.asarray(yarrow_base.annotations[1].polygon).shape[0]==10,"First Polygon Shape == 10"
 


### PR DESCRIPTION
There was a bug when multiple annotations were added at the same time :
```python
def test_create_multiple_annotations(yarrow_base:YarrowDataset,contributor_base:Contributor):
    """In this test we make sure adding annotations with different polygon shape is working.

    Args:
        yarrow (YarrowDataset): _description_
        contributor (Contributor): _description_
    """
    ann1 = Annotation(
        contributor_base,
        name='chaussure',
        images=yarrow_base.images,
        polygon=np.zeros((23,2))
    )
    ann2 = Annotation(
        contributor_base,
        name='chaussure',
        images=yarrow_base.images,
        polygon=np.zeros((10,2))
    )
    list_annotations = [ann1,ann2]
    yarrow_base.add_annotations(list_annotations)
```